### PR TITLE
Add minimum boss health requirement for success #336

### DIFF
--- a/analyser/analyser.py
+++ b/analyser/analyser.py
@@ -704,7 +704,7 @@ class Analyser:
         return success, success_time
 
     def validate_success(self, health_updates):
-        return self.validate_success_health(health_updates) # and self.validate_success_phases()
+        return self.validate_success_health(health_updates) and validate_minimum_health(health_updates) # and self.validate_success_phases()
 
     def validate_success_phases(self):
         success = len(self.phases) == len(list(filter(lambda a: a.important, self.boss_info.phases)))
@@ -717,4 +717,12 @@ class Analyser:
                 health_updates[health_updates.dst_agent <= (self.boss_info.success_health_limit * 100)].empty):
                 success = False
         print("Success changed due to health still being too high: {0}".format(not success))
+        return success
+    
+    def validate_minimum_health(self, health_updates):
+        success = True
+        if (self.boss_info.success_min_health_limit is not None and
+                not (health_updates[health_updates.dst_agent >= (self.boss_info.success_min_health_limit * 100)].empty)):
+                success = False
+        print("Success changed due to boss starting with less than minimum health: {0}".format(not success))
         return success

--- a/analyser/bosses.py
+++ b/analyser/bosses.py
@@ -304,7 +304,7 @@ BOSS_ARRAY = [
         Metric('Spatial Manipulation', 'Circles', MetricType.COUNT),
         Metric('Shared Agony', 'Agony', MetricType.COUNT)
     ], cm_detector = cairn_cm_detector, gather_stats = gather_cairn_stats),
-    Boss('Mursaat Overseer', Kind.RAID, [0x4314], enrage = 6 * MINUTES, metrics = [
+    Boss('Mursaat Overseer', Kind.RAID, [0x4314], enrage = 6 * MINUTES, success_min_health_limit = 95, metrics = [
         Metric('Protect', 'Protector', MetricType.COUNT),
         Metric('Claim', 'Claimer', MetricType.COUNT),
         Metric('Dispel', 'Dispeller', MetricType.COUNT),


### PR DESCRIPTION
This attempts to add a way to verify that the boss was at some minimum amount of health at some point in the fight. The first example of this (included in this pull request) would be verifying that there is some health update for Mursaat Overseer that states that it was at 95% or higher at some point.

95% for Mursaat Overseer was chosen because the normal version has a max health of 22,021,400, and 95% of that is 20,920,330. It's very unlikely that over 1 million health is going to be missing unless the boss was broken.

Previous outcome of uploading a glitched log file (say, MO starting at 33%): It would accept the log file and the log would show up on the leaderboard
Expected outcome of uploading a glitched log file (same as above): It should reject the log file because the boss wasn't anywhere near full health when the fight started.

Issue: https://github.com/GW2Raidar/gw2raidar/issues/336