### PR TITLE
Improvements to Restat: Only recalculate what's needed

### DIFF
--- a/raidar/management/commands/restat.py
+++ b/raidar/management/commands/restat.py
@@ -287,7 +287,7 @@ class Command(BaseCommand):
         def initialise_era_user_stats():
             return {}
 
-        def initialise_era_stats(count):
+        def initialise_era_stats():
             return {}
 
 
@@ -441,27 +441,29 @@ class Command(BaseCommand):
             if options['verbosity'] >= 3:
                 print()
                 print(title)
-                flattened = flatten(content)
-                for key in sorted(flattened.keys()):
-                    print_node(key, flattened[key])
+                # flattened = flatten(content)
+                # for key in sorted(flattened.keys()):
+                #     print_node(key, flattened[key])
 
-        def calculate_area_stats(era):
-            totals_in_era = initialise_era_stats(era.encounters.count())
+        def calculate_area_stats(era, new_encounters, forceRecalulation):
+            totals_in_era = initialise_era_stats()
 
-            area_queryset = Area.objects.all()
-            for area in area_queryset.iterator():
-                encounter_queryset = era.encounters.filter(area=area).order_by('?')
-                totals_in_area, leaderboards_in_area = initialise_era_area_stats()
+            area_queryset = new_encounters.order_by('area_id').distinct('area').values('area')
+            for area in area_queryset:
+                area_id = area['area']
+                if area_id:
+                    encounter_queryset = Encounter.objects.filter(area=area_id, era=era).order_by('?')
+                    totals_in_area, leaderboards_in_area = initialise_era_area_stats()
 
-                if area.id in BOSSES:
-                    kind = BOSSES[area.id].kind.name.lower()
-                else:
-                    kind = "unknown"
-                totals_for_kind = navigate(totals_in_era, 'kind', 'All %s bosses' % kind)
-                for encounter in encounter_queryset.iterator():
-                    add_encounter_to_era_area_stats(encounter, totals_in_area, totals_for_kind, leaderboards_in_area)
-                finalise_era_area_stats(era, area, totals_in_area, leaderboards_in_area)
-                verbose("Totals for era %s, area %s" % (era, area), totals_in_area)
+                    if area_id in BOSSES:
+                        kind = BOSSES[area_id].kind.name.lower()
+                    else:
+                        kind = "unknown"
+                    totals_for_kind = navigate(totals_in_era, 'kind', 'All %s bosses' % kind)
+                    for encounter in encounter_queryset.iterator():
+                        add_encounter_to_era_area_stats(encounter, totals_in_area, totals_for_kind, leaderboards_in_area)
+                    finalise_era_area_stats(era, area_id, totals_in_area, leaderboards_in_area)
+                    verbose("Totals for era %s, area %s" % (era, area_id), totals_in_area)
 
             finalise_era_stats(era, totals_in_era)
             verbose("Totals for era %s" % era, totals_in_era)
@@ -487,10 +489,13 @@ class Command(BaseCommand):
 
 
         for era in Era.objects.all():
-            new_encounters = Encounter.objects.filter(era=era, uploaded_at__gte=last_run)
-            forceRecalulation = options['force'];
-            if new_encounters or forceRecalulation:
-                calculate_area_stats(era)
+            forceRecalulation = options['force']
+            last_run_timestamp = last_run
+            if forceRecalulation:
+                last_run_timestamp = 0
+            new_encounters = Encounter.objects.filter(era=era, uploaded_at__gte=last_run_timestamp)
+            if new_encounters:
+                calculate_area_stats(era, new_encounters, forceRecalulation)
                 calculate_user_stats(era, new_encounters, forceRecalulation)
             elif options['verbosity'] >= 2:
                 print('Skipped era %s' % era)

--- a/raidar/management/commands/restat.py
+++ b/raidar/management/commands/restat.py
@@ -441,9 +441,9 @@ class Command(BaseCommand):
             if options['verbosity'] >= 3:
                 print()
                 print(title)
-                # flattened = flatten(content)
-                # for key in sorted(flattened.keys()):
-                #     print_node(key, flattened[key])
+                flattened = flatten(content)
+                for key in sorted(flattened.keys()):
+                    print_node(key, flattened[key])
 
         def calculate_area_stats(era, new_encounters, forceRecalulation):
             totals_in_era = initialise_era_stats()


### PR DESCRIPTION
Right now, for both areas and for users, if a single new log gets uploaded, the entire set of users and the entire set of areas gets recalculated, even though only the values associated with those logs could feasibly change.

This change makes it so that in the incremental case, we short circuit and only recalculate areas and users who we know have changed

Furthermore, we optimize the user case by updating their stat collection instead of re-calculating it from scratch each time. This has the current downside that a users stats wont update until a log containing their linked account is uploaded, but, currently that's a problem anyway (new users won't see stats until ~24 hours after they join). This can be solved by calculating a user's stats as part of sign up, once user stat calculation is changed to be dynamic/on demand instead of done as part of restat.