### PR TITLE
Faster, more efficient loading profile pages (!!!)

### DIFF
--- a/raidar/static/raidar/script.js
+++ b/raidar/static/raidar/script.js
@@ -694,14 +694,13 @@ ${body}
         'page.area': 'All raid bosses',
       });
       $.get({
-        url: 'profile.json',
+        url: getPageURLFromObject(page).substring(1) + '.json',
       }).then(setData).then(() => {
-        let eras = r.get('profile.eras');
-        let eraOrder = Object.values(eras)
-          .filter(era => 'encounter' in era.profile)
+        let era = r.get('profile.era');
+        let eraOrder =  Object.values(r.get('profile.eras_for_dropdown'))
           .sort((e1, e2) => e2.started_at - e1.started_at);
         r.set({
-          'page.era': eraOrder[0].id,
+          'page.era': Object.keys(era)[0],
           'profile.era_order': eraOrder,
         });
       });

--- a/raidar/templates/raidar/profile.html
+++ b/raidar/templates/raidar/profile.html
@@ -1,6 +1,6 @@
 {% load staticfiles %}
 [[#with profile]]
-  [[#with profile.eras[page.era]]]
+  [[#with profile.era[page.era]]]
     [[#with profile]]
       <div class="uk-button-group uk-width-1-1 boundary uk-margin-bottom uk-margin-top uk-visible@s">
         [[#each data.boss_locations]]
@@ -83,11 +83,11 @@
 
       <div>
         <h6 class="uk-font-family-secondary uk-text-uppercase">Time Frame</h6>
-        <button class="uk-button uk-width-auto@l uk-width-1-1 uk-margin-right@l" type="button">[[eras[page.era].name]] <i class="material-icons">expand_more</i></button>
+        <button class="uk-button uk-width-auto@l uk-width-1-1 uk-margin-right@l" type="button">[[name]] <i class="material-icons">expand_more</i></button>
         <div uk-dropdown="mode: click">
           <ul class="uk-nav uk-dropdown-nav">
             [[#each era_order]]
-              <li><a href="#" on-click="@this.set({'page.era': id})">[[name]]</a></li>
+              <li><a on-click="@this.fire('global_stats_nav', 'page.no', id)">[[name]]</a></li>
             [[/each]]
           </ul>
         </div>

--- a/raidar/urls.py
+++ b/raidar/urls.py
@@ -30,7 +30,7 @@ urlpatterns = [
     url(r'^change_password.json$', views.change_password, name = "change_password"),
     url(r'^add_api_key.json$', views.add_api_key, name = "add_api_key"),
     url(r'^encounter/(?P<url_id>\w+)(?P<json>\.json)?$', views.encounter, name = "encounter"),
-    url(r'^profile.json$', views.profile, name = "profile"),
+    url(r'^profile(?:/(?P<era_id>[0-9]+))?\.json$', views.profile, name = "profile"),
     url(r'^reset/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
         auth_views.password_reset_confirm, name='password_reset_confirm'),
     url(r'^reset/done/$', auth_views.password_reset_complete, name='password_reset_complete'),


### PR DESCRIPTION
1. Take a page out of global_stats book and load on a per era basis.

2. Optimize the backend to only load eras with data, and only fetch the EraArea relations for the area/era in question. It requires an additional SQL query roundtrip, but doesn't have to load the entire EraArea table into memory.

I think this should be more efficient, especially for the larger EraArea stats.