### PR TITLE
Stop initializing the page twice per load.

### DIFF
--- a/raidar/static/raidar/script.js
+++ b/raidar/static/raidar/script.js
@@ -928,15 +928,6 @@ ${body}
     }
     return false;
   }
-  let url = getPageURLFromObject(initPage);
-  history.replaceState(initPage, null, url);
-  if (pageInit[initPage.name]) {
-    pageInit[initPage.name](initPage);
-  }
-  if (window.ga) {
-    window.ga('set', 'page', url);
-    window.ga('send', 'pageview');
-  }
 
   function notification(str, style) {
     UIkit.notification(str, style);


### PR DESCRIPTION
I'm convinced this was a javascript mistake, but this should prevent us from calling pageInit (and making 2 network roundtrips) per page load.

Gotta test this a bit to make sure nothing's busted.