### PR TITLE
Added hotfix for "EVTC missing end event" error

### DIFF
--- a/evtcparser/parser.py
+++ b/evtcparser/parser.py
@@ -233,12 +233,16 @@ class Encounter:
             self.events = pd.DataFrame(np.fromstring(events_string, dtype=EVENT_DTYPE))
 
         if len(self.events[self.events.state_change == StateChange.LOG_END]) == 0:
-            raise EvtcParseException('EVTC missing end event')
+            pass
+            # raise EvtcParseException('EVTC missing end event')
+        else:
+            self.log_ended_at = self.events[self.events.state_change == StateChange.LOG_END]['value'].iloc[-1]
+
         log_start_events = self.events[self.events.state_change == StateChange.LOG_START]['value']
         if len(log_start_events) == 0:
             raise EvtcParseException('EVTC missing start event')
-        self.log_started_at = log_start_events.iloc[0]
-        self.log_ended_at = self.events[self.events.state_change == StateChange.LOG_END]['value'].iloc[-1]
+        else:
+            self.log_started_at = log_start_events.iloc[0]
 
     def _old_add_inst_id_to_agents(self):
         


### PR DESCRIPTION
The error message can be ignored, since we're not using EvtcEncounter.log_ended_at in the entire code.