### PR TITLE
Remove old website from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ Introduction
 ----------
 GW2 Raidar is a web application to parse [ARCDPS log files](https://deltaconnected.com/arcdps/) for Guild Wars 2. In addition, nearly all metrics and statistics are compiled into a global database for comparison and further insights. 
 
-https://www.gw2raidar.com
-
 Due to time constraints and the ever increasing list of features and requests, we have decided to finally go open source to hopefully speed up the development of certain new features as well as speedy fixing of bugs encountered. Feature requests and bug reports are welcome! You can submit them via our [Discord](http://discord.gg/8j43kAc) or [issues log](https://github.com/merforga/gw2raidar/issues)
 
 Contributing


### PR DESCRIPTION
The website that was listed in the README has been purchased by somebody else and now redirects to a scam site.